### PR TITLE
LLTextureFetchWorker::doWork - Add Decode Queue Size Check

### DIFF
--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -1761,7 +1761,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
         if ((S32)LLAppViewer::getImageDecodeThread()->getPending() >= 1024)
         {
             // No room in decode queue, wait in state for opening. LLThreadSafeQueue default is 1024.
-            LL_DEBUGS(LOG_TXT) << mID << " DECODE_IMAGE wait: Decode queue full!" << LL_ENDL;
+            LL_DEBUGS_ONCE(LOG_TXT) << mID << " DECODE_IMAGE wait: Decode queue full!" << LL_ENDL;
             return false;
         }
         mDecodeTimer.reset();

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -1758,6 +1758,12 @@ bool LLTextureFetchWorker::doWork(S32 param)
             LL_DEBUGS(LOG_TXT) << mID << " DECODE_IMAGE abort: mLoadedDiscard < 0" << LL_ENDL;
             return true;
         }
+        if ((S32)LLAppViewer::getImageDecodeThread()->getPending() >= 1024)
+        {
+            // No room in decode queue, wait in state for opening. LLThreadSafeQueue default is 1024.
+            LL_DEBUGS(LOG_TXT) << mID << " DECODE_IMAGE wait: Decode queue full!" << LL_ENDL;
+            return false;
+        }
         mDecodeTimer.reset();
         mRawImage = NULL;
         mAuxImage = NULL;


### PR DESCRIPTION
Make sure there is room in the decode queue before submitting work from the texture fetch worker.

Used a greater than or equal comparison just in case something weird happens, against 1024 since it's the default capacity value for LLThreadSafeQueue and returning false to make sure it attempts the decode again until decode queue length reduces. Threw a message into debug so we can see when it is happening.

This might not seem necessary but I have hit this limit in the last several days while testing ideas for the texture fetch queue and it caused the viewer to seize.

Obligatory, OpenJPEG 2.5.3 and X3D cache goes BRRRRR!